### PR TITLE
feat: open announcement link in a new tab

### DIFF
--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -99,6 +99,7 @@
                       <a
                         href="{{ block.settings.link }}"
                         class="announcement-bar__link link link--text focus-inset animate-arrow"
+                        target="_blank"
                       >
                     {%- endif -%}
                     <p class="announcement-bar__message h5">


### PR DESCRIPTION
add target _blank

### PR Summary: 

Adding announcement link to new tab

### Why are these changes introduced?

Losing customers by opening in same tab as the browser. 

